### PR TITLE
Allow different tags on each log statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ _LTracker.push({
 });
 ```
 
+By default, tags are set once and are then immutable. To enable changing the tag with each log statement, set `mutableTags` to true when initializing:
+
+```Javascript
+_LTracker.push({
+  'logglyKey': 'your-customer-token',
+  'sendConsoleErrors' : true,
+  'tag' : 'tag1,tag2',
+  'mutableTags' : true
+});
+```
+
+If mutable tags are enabled, any log object passed with a 'tag' key will overwrite the previous tags.
+
 Setup Proxy for Ad blockers
 ----------
 You can proxy the requests from your own domain if the script or its requests are blocked by Ad blockers. To do this, you need to perform following steps

--- a/src/loggly.tracker.js
+++ b/src/loggly.tracker.js
@@ -27,8 +27,15 @@
     }
     
     function setTag(tracker, tag){		
-        tracker.tag = tag;		
-    }	
+        tracker.tag = tag;
+        if (tracker.mutableTags) {
+            setInputUrl(tracker);
+        }
+    }
+
+    function setMutableTags(tracker) {
+        tracker.mutableTags = true;
+    }
     
     function setDomainProxy(tracker, useDomainProxy){
         tracker.useDomainProxy = useDomainProxy;
@@ -118,6 +125,10 @@
 		if(data.sendConsoleErrors !== undefined) {
 		    setSendConsoleError(self, data.sendConsoleErrors);
                 }
+
+             if (data.mutableTags) {
+                setMutableTags(self);
+             }
                	
 		if(data.tag) {
                     setTag(self, data.tag);


### PR DESCRIPTION
This change adds a flag during initialization (`mutableTags`) that, when true, checks each object passed to _LTracker and if it contains a tags field, resets the tracker's tag to the new field. This allows different tags for each logging statement.

Happy to add some documentation as well.
