### PR TITLE
Sync package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/dist
 /node_modules
 
 # Ignore everything in src folder except for loggly.tracker.js file

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-/dist
 /node_modules
 
 # Ignore everything in src folder except for loggly.tracker.js file
 /src/*
-# !/src/loggly.tracker.js
-
+!/src/loggly.tracker.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,12 +5,12 @@ module.exports = function (grunt) {
     uglify: {
       options: {
         sourceMap: true,
-        sourceMapName: 'src/loggly.tracker-' + packageJson.version + '.min.map'
+        sourceMapName: 'dist/loggly.tracker-' + packageJson.version + '.min.map'
       },
       main: {
         files: [{
         src: 'src/loggly.tracker.js',
-        dest: 'src/loggly.tracker-' + packageJson.version + '.min.js'
+        dest: 'dist/loggly.tracker-' + packageJson.version + '.min.js'
       }]
       }
     }

--- a/README.md
+++ b/README.md
@@ -95,5 +95,6 @@ Build min and map file
 ----------
 You can build min and map file by using the command below:
 ```
+npm install
 grunt uglify
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loggly-jslogger",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A Javascript client to send logs to Loggly.",
   "browser": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loggly-jslogger",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "A Javascript client to send logs to Loggly.",
   "browser": "index.js",
   "repository": {


### PR DESCRIPTION
I have upgraded the package version to `2.2.1` in `package.json` file same as the published npm package version so that on deploying it on the CDN, the version will remain in sync in all places.

Ref: https://www.npmjs.com/package/loggly-jslogger