### PR TITLE
Add copy task runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 /dist
 /node_modules
-
-# Ignore everything in src folder except for loggly.tracker.js file
-/src/*
-!/src/loggly.tracker.js

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,3 @@ Gruntfile.js
 bower.json
 .editorconfig
 package-lock.json
-
-# Allow everything under src directory
-!/src/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,12 +9,48 @@ module.exports = function (grunt) {
       },
       main: {
         files: [{
-        src: 'src/loggly.tracker.js',
-        dest: 'dist/loggly.tracker-' + packageJson.version + '.min.js'
-      }]
+            src: 'src/loggly.tracker.js',
+            dest: 'dist/loggly.tracker-' + packageJson.version + '.min.js'
+          }]
+      },
+    },
+    copy: {
+      main: {
+        files: [{
+          expand: true,
+          cwd: 'src',
+          src: 'loggly.tracker.js',
+          dest: 'dist/',
+        },{
+          expand: true,
+          src: 'src/loggly.tracker.js',
+          rename: function () {
+            return 'dist/loggly.tracker-latest.js';
+          }
+        },{
+          expand: true,
+          src: 'src/loggly.tracker.js',
+          rename: function () {
+            return 'dist/loggly.tracker-' + packageJson.version + '.js';
+          }
+        },{
+          expand: true,
+          src: 'dist/loggly.tracker-' + packageJson.version + '.min.map',
+          rename: function () {
+            return 'dist/loggly.tracker-latest.min.map';
+          }
+        },{
+          expand: true,
+          src: 'dist/loggly.tracker-' + packageJson.version + '.min.js',
+          rename: function () {
+            return 'dist/loggly.tracker-latest.min.js';
+          }
+        }
+        ]
       }
-    }
+    },
   });
   grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.registerTask('default', ['uglify']);
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.registerTask('default', ['uglify', 'copy']);
 };

--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ Build min and map file
 You can build min and map file by using the command below:
 ```
 npm install
-grunt uglify
+grunt
 ```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "bower": "^1.8.0",
     "grunt": "^1.0.1",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-uglify": "^3.0.1"
   }
 }


### PR DESCRIPTION
- Add copy task runner in the Gruntfile.js file so that the loggly.tracker.js file can be copied to /dist folder. 

-And using the rename function, I have created the loggly.tracker.min.js, loggly.tracker.min.map and loggly.tracker.js files with "latest" and json package version within their names.

- Update the command in Readme.md