### PR TITLE
Support special characters readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loggly-jslogger",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A Javascript client to send logs to Loggly.",
   "browser": "index.js",
   "repository": {

--- a/src/loggly.tracker.js
+++ b/src/loggly.tracker.js
@@ -18,6 +18,7 @@
         this.sendConsoleErrors = false;
         this.tag = 'jslogger';
         this.useDomainProxy = false;
+        this.useUtfEncoding = false;
     }
 
     function setKey(tracker, key) {
@@ -34,6 +35,10 @@
         tracker.useDomainProxy = useDomainProxy;
         //refresh inputUrl value
         setInputUrl(tracker);
+    }
+
+    function setUtfEncoding(tracker, useUtfEncoding){
+        tracker.useUtfEncoding = useUtfEncoding;
     }
 
     function setSendConsoleError(tracker, sendConsoleErrors) {
@@ -124,6 +129,10 @@
                     setTag(self, data.tag);
                 }
 
+                if (data.useUtfEncoding !== undefined) {
+                    setUtfEncoding(self, data.useUtfEncoding);
+                }
+
                 if (data.useDomainProxy) {
                     setDomainProxy(self, data.useDomainProxy);
                 }
@@ -155,7 +164,11 @@
                 //creating an asynchronous XMLHttpRequest
                 var xmlHttp = new XMLHttpRequest();
                 xmlHttp.open('POST', this.inputUrl, true); //true for asynchronous request
-                xmlHttp.setRequestHeader('Content-Type', 'text/plain');
+                if (tracker.useUtfEncoding === true) {
+                    xmlHttp.setRequestHeader('Content-Type', 'text/plain; charset=utf-8');
+                } else {
+                    xmlHttp.setRequestHeader('Content-Type', 'text/plain');
+                }
                 xmlHttp.send(JSON.stringify(data));
 
             } catch (ex) {


### PR DESCRIPTION
Hi, In this PR, I have added a new flag variable which is configurable and will include the `charset=utf-8` property in the `request header`. This will enable the better readability of special characters being send in the log events. 

This has been tested completely and ready to merge. @psamit can you please review. 

Thanks!