### PR TITLE
Update README file for new flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ _LTracker.push({
 });
 ```
 
+Special Characters Support
+----
+Keeping <strong>useUtfEncoding</strong> to <i>true</i> will prevent the Special Characters to being garbled on Loggly Search. You will be able to read and understand the included Special Characters in your log events more easily.
+
+Please see the usage  below-
+
+```Javascript
+_LTracker.push({
+      'logglyKey': 'your-customer-token',
+      'sendConsoleErrors' : true,
+      'tag' : 'javascript-logs',
+      'useUtfEncoding': true
+});
+```
+
 Setup Proxy for Ad blockers
 ----------
 You can proxy the requests from your own domain if the script or its requests are blocked by Ad blockers. To do this, you need to perform following steps


### PR DESCRIPTION
In this PR, I have updated the README file to include information about the new flag: `useUtfEncoding`. This will enable the `utf-8` encoding and the customers will be able to read and understand special characters included in their log events. 

