### PR TITLE
LOG-7782 Added https in the src path of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation
 
 Place the following on your page, and replace the logglyKey value with the key provided by the website:
 ```html
-<script type="text/javascript" src="//cloudfront.loggly.com/js/loggly.tracker-latest.min.js" async></script>
+<script type="text/javascript" src="https://cloudfront.loggly.com/js/loggly.tracker-latest.min.js" async></script>
 <script>
   var _LTracker = _LTracker || [];
   _LTracker.push({


### PR DESCRIPTION
The current path of **src** (//cloudfront.loggly.com/js/loggly.tracker-latest.min.js) in README.md causes an error **index_test.html:4 GET file://cloudfront.loggly.com/js/loggly.tracker-latest.min.js net::ERR_FILE_NOT_FOUND**

I changed path to https://cloudfront.loggly.com/js/loggly.tracker-latest.min.js to fix the error